### PR TITLE
Bump pyo3 to 0.13 + further cleanup

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ failure = "0.1.6"
 serde = "1.0.103"
 serde_derive = "1.0.103"
 serde_dhall = "0.10.0"
-pyo3 = "0.12.3"
+pyo3 = "0.13.2"
 
 [lib]
 name = "dhall"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,12 +23,12 @@ classifier = [
 ]
 
 [dependencies]
-serde_json = "1.0.42"
-failure = "0.1.6"
-serde = "1.0.103"
-serde_derive = "1.0.103"
-serde_dhall = "0.10.0"
-pyo3 = "0.13.2"
+serde_json = "1"
+serde = "1"
+serde_derive = "1"
+serde_dhall = "0.10"
+pyo3 = "0.13"
+thiserror = "1"
 
 [lib]
 name = "dhall"

--- a/Makefile
+++ b/Makefile
@@ -6,19 +6,15 @@ publish: ## Publish the binding
 	twine upload target/wheels/dhall*.whl
 
 .PHONY: build
-build: nightly dev-packages ## Builds Rust code and dhall-python Python modules
-	poetry run maturin build --manylinux 2010-unchecked --rustc-extra-args="-Wall"
+build: dev-packages ## Builds Rust code and dhall-python Python modules
+	poetry run maturin build --manylinux 2010 --skip-auditwheel --rustc-extra-args="-Wall"
 
 .PHONY: build-release
-build-release: nightly dev-packages ## Build dhall-python module in release mode
-	poetry run maturin build --manylinux 2010-unchecked --release
-
-.PHONY: nightly
-nightly: ## Set rust compiler to nightly version
-	rustup override set nightly
+build-release: dev-packages ## Build dhall-python module in release mode
+	poetry run maturin build --manylinux 2010 --skip-auditwheel --release
 
 .PHONY: install
-install: nightly dev-packages ## Install dhall-python module into current virtualenv
+install: dev-packages ## Install dhall-python module into current virtualenv
 	poetry run maturin develop --release
 
 .PHONY: publish

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,20 +13,21 @@ keywords = ["dhall", "python"]
 python = "^3.6"
 
 [tool.poetry.dev-dependencies]
-pytest = "^6.1"
-pylint = "^2.6"
-flake8 = "^3.5"
+pytest = "~=6.1"
+pylint = "~=2.6"
+flake8 = "~=3.5"
 wheel = "*"
 pytest-runner = "*"
 pytest-benchmark = "*"
 hypothesis = "*"
 autopep8 = "*"
-maturin = "==0.9.0"
+maturin = "~=0.9"
 
 [build-system]
 requires = ["maturin"]
 build-backend = "maturin"
 
 [tool.maturin]
-manylinux = "2010-unchecked"
+manylinux = "2010"
+skip-auditwheel = true
 sdist-include = ["dhall/*"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,3 @@
-use failure::Fail;
 use std::collections::BTreeMap;
 use std::fmt;
 use std::marker::PhantomData;
@@ -8,21 +7,22 @@ use pyo3::prelude::*;
 use pyo3::types::{PyAny, PyDict, PyFloat, PyList, PyTuple};
 use pyo3::{import_exception, wrap_pyfunction};
 use serde_dhall::{NumKind, SimpleValue};
+use thiserror::Error;
 
 use serde::de::{self, DeserializeSeed, Deserializer, MapAccess, SeqAccess, Visitor};
 use serde::ser::{self, Serialize, SerializeMap, SerializeSeq, Serializer};
 
-#[derive(Debug, Fail)]
+#[derive(Debug, Error)]
 pub enum DhallPythonError {
-    #[fail(display = "Conversion error: {}", error)]
+    #[error("Conversion error: {error}")]
     InvalidConversion { error: serde_dhall::Error },
-    #[fail(display = "Python Runtime exception: {}", error)]
+    #[error("Python Runtime exception: {error}")]
     PyErr { error: String },
-    #[fail(display = "Dictionary key is not a string: {:?}", obj)]
+    #[error("Dictionary key is not a string: {obj:?}")]
     DictKeyNotString { obj: PyObject },
-    #[fail(display = "Invalid float: {}", x)]
+    #[error("Invalid float: {x}")]
     InvalidFloat { x: String },
-    #[fail(display = "Invalid type: {}, Error: {}", t, e)]
+    #[error("Invalid type: {t}, Error: {e}")]
     InvalidCast { t: String, e: String },
     // NoneError doesn't have an impl for `Display`
     // See https://github.com/rust-lang-nursery/failure/issues/61

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -321,8 +321,8 @@ impl<'p, 'a> Serialize for SerializePyObject<'p, 'a> {
                 repr,
             ))),
             Err(_) => Err(ser::Error::custom(format_args!(
-                "Type is not JSON serializable: {}",
-                self.obj.get_type().name().into_owned(),
+                "Type is not JSON serializable: {:?}",
+                self.obj.get_type().name(),
             ))),
         }
     }


### PR DESCRIPTION
https://github.com/PyO3/pyo3/blob/master/CHANGELOG.md#changed-2 indicates `PyType::name()` is a result.

Replaces https://github.com/s-zeng/dhall-python/pull/23
Replaces https://github.com/s-zeng/dhall-python/pull/26