### PR TITLE
[DRAFT] Fix CI build error

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,7 +68,7 @@ jobs:
           override: true
 
       - name: Build Python package
-        run: poetry run maturin develop --release
+        run: poetry run maturin develop --release --cargo-extra-args="--verbose"
 
       - name: pytest
         run: poetry run pytest tests


### PR DESCRIPTION
Current weekly builds fail due to ubuntu's rust being unable to download the `cfg-if` crate for some reason. This PR is my attempt to look into that